### PR TITLE
fix: require VSCode 1.66.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "./packages/*"
   ],
   "engines": {
-    "vscode": "^1.63.0"
+    "vscode": "^1.66.0"
   },
   "categories": [
     "Other"

--- a/test/integration/runTests.ts
+++ b/test/integration/runTests.ts
@@ -3,6 +3,7 @@ import { runCLI } from 'jest';
 import { runTests } from '@vscode/test-electron';
 import type { Config } from '@jest/types';
 import { test_process } from './test-process';
+import * as meta from '../../package.json';
 
 export async function run(): Promise<void> {
   // jest doesn't seem to provide a way to inject global/dynamic imports.
@@ -51,6 +52,7 @@ async function main() {
         path.resolve(projectPath, './test/workspace'),
 				"--disable-extensions"
       ],
+      version: meta.engines.vscode.replace(/^(\^|~)/, ''),
       platform: process.platform == 'win32' ? 'win32-x64-archive' : undefined
     });
   } catch (err) {


### PR DESCRIPTION
Arrow.js uses Array.at() which is supported only from node 16.6.0