### PR TITLE
ci: remove macos-12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         os:
           - ubuntu-20.04
           - windows-2019
-          - macos-12
           - macos-14
     env:
       CONAN_HOME: "${{ github.workspace }}/conan-cache"


### PR DESCRIPTION
it has been deprecated in https://github.com/actions/runner-images/issues/10721