### PR TITLE
fix: restrict logging.folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,8 +132,7 @@
     "untrustedWorkspaces": {
       "supported": "limited",
       "restrictedConfigurations": [
-        "parquet-viewer.useParquetTools",
-        "parquet-viewer.parquetToolsPath"
+        "parquet-viewer.logging.folder"
       ]
     }
   },

--- a/packages/parquet-reader/conan.lock
+++ b/packages/parquet-reader/conan.lock
@@ -26,7 +26,7 @@
         "m4/1.4.19#b38ced39a01e31fef5435bc634461fd2%1700758725.451",
         "flex/2.6.4#e35bc44b3fcbcd661e0af0dc5b5b1ad4%1674818991.113",
         "cmake/3.31.8#dde3bde00bb843687e55aea5afa0e220%1751628300.59",
-        "bison/3.8.2#ed1ba0c42d2ab7ab64fc3a62e9ecc673%1688556312.342",
+        "bison/3.8.2#c3490cbe0078b6fd3eb4cf5ed64144dc",
         "b2/5.3.3#107c15377719889654eb9a162a673975%1750340310.079"
     ],
     "python_requires": [],


### PR DESCRIPTION
Tested by opened a non-trusted workspace, changing the value of `logging.folder` settings and verifying code still sees an empty string.

Fixes #199